### PR TITLE
Set isSpeaking as false when ChattyKathy shuts up

### DIFF
--- a/ChattyKathy.js
+++ b/ChattyKathy.js
@@ -68,6 +68,7 @@ function ChattyKathy(settings) {
 
     // Quit talking
     function shutUp() {
+        isSpeaking = false;
         audioElement.pause();
         playlist = [];
     }


### PR DESCRIPTION
setting isSpeaking=false allows ChattKathy to say() again after previous shutUp